### PR TITLE
fix cli templates error

### DIFF
--- a/flexget/plugins/cli/templates.py
+++ b/flexget/plugins/cli/templates.py
@@ -19,8 +19,11 @@ def list_file_templates(manager, options):
         else:
             plugin = '-'
         name = template_name.replace('.template', '').split('/')
-        if len(name) == 2:
-            name = name[1]
+        if type(name) == list:
+            if len(name) > 0:
+                name = name[-1]
+            else:
+                name = '<ERR>'
         with open(template.filename) as contents:
             table_data.append([name, plugin, template.filename, contents.read()])
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/local/bin/flexget", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/dist-packages/flexget/__init__.py", line 44, in main
    manager.start()
  File "/usr/local/lib/python3.9/dist-packages/flexget/manager.py", line 383, in start
    self.handle_cli()
  File "/usr/local/lib/python3.9/dist-packages/flexget/manager.py", line 412, in handle_cli
    options.cli_command_callback(self, command_options)
  File "/usr/local/lib/python3.9/dist-packages/flexget/plugins/cli/templates.py", line 31, in list_file_templates
    table.add_row(name, plugin, template.filename, '')
  File "/usr/local/lib/python3.9/dist-packages/rich/table.py", line 423, in add_row
    raise errors.NotRenderableError(
rich.errors.NotRenderableError: unable to render list; a string or other renderable object is required
```
